### PR TITLE
fix: Restore alignment of Reveal button in Obsidian v0.16.*

### DIFF
--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -50,7 +50,7 @@ export class RevealActiveFileButtonPlugin extends Plugin {
 
     const newIcon = document.createElement('div');
     this.setButtonProperties(newIcon);
-    newIcon.className = 'nav-action-button reveal-active-file-button';
+    newIcon.className = 'clickable-icon nav-action-button reveal-active-file-button';
     this.registerDomEvent(newIcon, 'click', () => {
       this.onButtonClick(explorer);
     });


### PR DESCRIPTION
Button is misaligned in v0.16.0 with the new default theme. Adding this missing class fixes it.

Before
![image](https://user-images.githubusercontent.com/4851889/187299638-81b16a15-ec13-410a-b41a-ce8c408d3492.png)

After
![image](https://user-images.githubusercontent.com/4851889/187299703-6cfbdb70-ec99-4632-9924-bc5257a43b88.png)
