### PR TITLE
Fix issue where Reveal button requires two clicks

### DIFF
--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -72,8 +72,13 @@ export class RevealActiveFileButtonPlugin extends Plugin {
    */
   private onButtonClick(explorer: WorkspaceLeaf): void {
     if (explorer) {
-      //@ts-ignore
+      // @ts-ignore
       this.app.commands.executeCommandById('file-explorer:reveal-active-file');
+      // Send the command twice like a double-click, to handle the frequent case where Obsidian fails to jump to the file
+      setTimeout(() => {
+        // @ts-ignore
+        this.app.commands.executeCommandById('file-explorer:reveal-active-file');
+      }, 50)
     }
   }
 


### PR DESCRIPTION
Hi @claremacrae . I have a large vault with many files, and I experience the bug nearly every time where Obsidian doesn't jump to the file unless the button is clicked a second time.

To resolve this, I suggest the attached code, which just always sends the event two times in succession.

I have not experienced any issues with this code, and for me it completely resolves the bug of Obsidian not fully jumping.